### PR TITLE
fix typo on column cpc_data_source of table tls225_docdb_fam_cpc

### DIFF
--- a/create_patstat_tables.sql
+++ b/create_patstat_tables.sql
@@ -182,7 +182,7 @@ CREATE TABLE tls225_docdb_fam_cpc (
     cpc_value char(1) DEFAULT '' NOT NULL,
     cpc_action_date date DEFAULT '9999-12-31' NOT NULL,
     cpc_status char(1) DEFAULT '' NOT NULL,
-    cpc data_source char(1) DEFAULT '' NOT NULL
+    cpc_data_source char(1) DEFAULT '' NOT NULL
 );
 
 CREATE TABLE tls226_person_orig (


### PR DESCRIPTION
The column cpc_data_source had a space. Was "cpc data_source". This fix adds the missing underscore.